### PR TITLE
Adicionar política de retry ao solid `update_view`

### DIFF
--- a/repositories/libraries/basedosdados/solids.py
+++ b/repositories/libraries/basedosdados/solids.py
@@ -6,6 +6,7 @@ from dagster import (
     SolidExecutionContext,
     Nothing,
     Field,
+    RetryPolicy
 )
 
 from google.cloud import bigquery
@@ -17,7 +18,7 @@ import basedosdados as bd
 from repositories.libraries.jinja2.solids import render
 
 
-@solid
+@solid(retry_policy=RetryPolicy(max_retries=3, delay=5))
 def update_view(context: SolidExecutionContext, view_sql: str, table_name: str, delete: bool = False) -> Nothing:
 
     # Table ID can't be empty


### PR DESCRIPTION
## Issues relacionadas 

- https://github.com/RJ-SMTR/maestro/issues/33

## Motivação

Em alguns casos a API do BigQuery pode falhar ao atualizar a view. De forma a garantir que é exclusivamente um problema de rede (e não de SQL e afins) adicionam-se três novas tentativas com delay de 5 segundos entre cada.