### PR TITLE
Adiciona materialized views

### DIFF
--- a/repositories/helpers/constants.py
+++ b/repositories/helpers/constants.py
@@ -6,3 +6,7 @@ class constants(Enum):
     Constants for the repositories
     """
     REDIS_HOST = 'dagster-redis-master'
+    MAESTRO_REPOSITORY = "RJ-SMTR/maestro"
+    MAESTRO_DEFAULT_BRANCH = "main"
+    MAESTRO_BQ_REPOSITORY = "RJ-SMTR/maestro-bq"
+    MAESTRO_BQ_DEFAULT_BRANCH = "master"

--- a/repositories/helpers/constants.py
+++ b/repositories/helpers/constants.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class constants(Enum):
+    """
+    Constants for the repositories
+    """
+    REDIS_HOST = 'dagster-redis-master'

--- a/repositories/helpers/datetime.py
+++ b/repositories/helpers/datetime.py
@@ -1,3 +1,4 @@
+import croniter
 import datetime
 
 
@@ -17,3 +18,41 @@ def convert_datetime_to_unix_time(datetime: datetime.datetime):
     :return: A unix time.
     """
     return datetime.timestamp()
+
+
+def determine_whether_to_execute_or_not(cron_expression: str, datetime_now: datetime.datetime, datetime_last_execution: datetime.datetime):
+    """
+    Determines whether the cron expression is currently valid.
+    :param cron_expression: The cron expression to check.
+    :param datetime_now: The current datetime.
+    :param datetime_last_execution: The last datetime the cron expression was executed.
+    :return: True if the cron expression is valid, False otherwise.
+    """
+    cron_expression_iterator = croniter.croniter(
+        cron_expression, datetime_last_execution)
+    next_cron_expression_time = cron_expression_iterator.get_next(
+        datetime.datetime)
+    if next_cron_expression_time < datetime_now:
+        return True
+    else:
+        return False
+
+
+def convert_datetime_string_to_datetime(datetime_string: str, format: str = "%Y-%m-%d %H:%M:%S"):
+    """
+    Converts a datetime string to a datetime object.
+    :param datetime_string: The datetime string to convert.
+    :param format: Format for conversion. Default is "%Y-%m-%d %H:%M:%S".
+    :return: A datetime object.
+    """
+    return datetime.datetime.strptime(datetime_string, format)
+
+
+def convert_datetime_to_datetime_string(datetime: datetime.datetime, format: str = "%Y-%m-%d %H:%M:%S"):
+    """
+    Converts a datetime object to a datetime string.
+    :param datetime: The datetime object to convert.
+    :param format: Format for conversion. Default is "%Y-%m-%d %H:%M:%S".
+    :return: A datetime string.
+    """
+    return datetime.strftime(format)

--- a/repositories/helpers/hooks.py
+++ b/repositories/helpers/hooks.py
@@ -4,6 +4,7 @@ import requests
 from croniter import croniter
 from datetime import datetime
 from redis_pal import RedisPal
+from repositories.helpers.constants import constants
 
 
 @success_hook(required_resource_keys={"discord_webhook", "timezone_config"})
@@ -28,15 +29,14 @@ def discord_message_on_failure(context: HookContext):
 
 @success_hook(required_resource_keys={"keepalive_key"})
 def redis_keepalive_on_succes(context: HookContext):
-    rp = RedisPal(host="dagster-redis-master")
+    rp = RedisPal(host=constants.REDIS_HOST.value)
     rp.set(context.resources.keepalive_key['key'], 1)
 
 
 @failure_hook(required_resource_keys={"discord_webhook", "keepalive_key"})
 def redis_keepalive_on_failure(context: HookContext):
-    rp = RedisPal(host="dagster-redis-master")
+    rp = RedisPal(host=constants.REDIS_HOST.value)
     rp.set(context.resources.keepalive_key['key'], 1)
     message = f"Although solid {context.solid.name} has failed, a keep-alive was sent to Redis!"
     url = context.resources.discord_webhook["url"]
     requests.post(url, data={"content": message})
-

--- a/repositories/helpers/io.py
+++ b/repositories/helpers/io.py
@@ -2,6 +2,7 @@ import os
 import time
 import json
 import base64
+import requests
 
 from google.oauth2 import service_account
 from google.cloud import storage, bigquery
@@ -153,3 +154,17 @@ def parse_filepath_to_tablename(filepath: str) -> str:
 
     # Returns full BQ name
     return ".".join([prefix, dataset_name, table_name])
+
+
+def fetch_branch_sha(github_repo_name: str, branch_name: str):
+    """Fetches the SHA of a branch from Github"""
+    url = f"https://api.github.com/repos/{github_repo_name}/git/refs"
+    response = requests.get(url)
+    if response.status_code != 200:
+        return None
+    else:
+        branches = response.json()
+        for branch in branches:
+            if branch["ref"] == f"refs/heads/{branch_name}":
+                return branch["object"]["sha"]
+    return None

--- a/repositories/helpers/io.py
+++ b/repositories/helpers/io.py
@@ -21,10 +21,10 @@ def get_bigquery_client() -> bigquery.Client:
     return bigquery.Client(project=os.getenv("BQ_PROJECT_NAME"), credentials=credentials)
 
 
-def run_query(query: str):
+def run_query(query: str, timeout: float = None):
     """Runs a query on BigQuery"""
     client = get_bigquery_client()
-    return client.query(query).result()
+    return client.query(query, timeout=timeout).result()
 
 
 def insert_results_to_table(row_iterator: RowIterator, table_name: str) -> list:

--- a/repositories/queries/materialized_views_base_config.yaml
+++ b/repositories/queries/materialized_views_base_config.yaml
@@ -1,5 +1,4 @@
-# TODO: fill these in pipeline
-run id: ""
+run_key: ""
 run_timestamp: ""
 maestro_sha: ""
 maestro_bq_sha: ""

--- a/repositories/queries/materialized_views_base_config.yaml
+++ b/repositories/queries/materialized_views_base_config.yaml
@@ -1,0 +1,5 @@
+# TODO: fill these in pipeline
+run id: ""
+run_timestamp: ""
+maestro_sha: ""
+maestro_bq_sha: ""

--- a/repositories/queries/materialized_views_execute.yaml
+++ b/repositories/queries/materialized_views_execute.yaml
@@ -1,0 +1,41 @@
+solids:
+  delete_table_on_query_change:
+    inputs:
+      table_name:
+        value: ""
+      changed:
+        value: false
+  create_table_if_not_exists:
+    inputs:
+      base_query:
+        value: ""
+      base_params:
+        value: ""
+      query_params:
+        value: ""
+      table_name:
+        value: ""
+      now:
+        value: ""
+  insert_into_table_if_already_existed:
+    inputs:
+      base_query:
+        value: ""
+      base_params:
+        value: ""
+      query_params:
+        value: ""
+      table_name:
+        value: ""
+      last_run:
+        value: ""
+      now:
+        value: ""
+resources:
+  timezone_config:
+    config:
+      timezone: "America/Sao_Paulo"
+  discord_webhook:
+    config:
+      url: "{{ '' | env_override('QUERIES_DISCORD_WEBHOOK') }}"
+      success_cron: "* * * * *"

--- a/repositories/queries/materialized_views_execute.yaml
+++ b/repositories/queries/materialized_views_execute.yaml
@@ -1,36 +1,8 @@
 solids:
-  delete_table_on_query_change:
+  resolve_dependencies_and_execute:
     inputs:
-      table_name:
-        value: ""
-      changed:
-        value: false
-  create_table_if_not_exists:
-    inputs:
-      base_query:
-        value: ""
-      base_params:
-        value: ""
-      query_params:
-        value: ""
-      table_name:
-        value: ""
-      now:
-        value: ""
-  insert_into_table_if_already_existed:
-    inputs:
-      base_query:
-        value: ""
-      base_params:
-        value: ""
-      query_params:
-        value: ""
-      table_name:
-        value: ""
-      last_run:
-        value: ""
-      now:
-        value: ""
+      queries_names:
+        value: []
 resources:
   timezone_config:
     config:

--- a/repositories/queries/materialized_views_update.yaml
+++ b/repositories/queries/materialized_views_update.yaml
@@ -1,0 +1,19 @@
+solids:
+  update_materialized_view_on_redis:
+    inputs:
+      blob_name:
+        value: ""
+      cron_expression:
+        value: ""
+      delete:
+        value: false
+      query_modified:
+        value: false
+resources:
+  timezone_config:
+    config:
+      timezone: "America/Sao_Paulo"
+  discord_webhook:
+    config:
+      url: "{{ '' | env_override('QUERIES_DISCORD_WEBHOOK') }}"
+      success_cron: "* * * * *"

--- a/repositories/queries/materialized_views_update.yaml
+++ b/repositories/queries/materialized_views_update.yaml
@@ -9,6 +9,12 @@ solids:
         value: false
       query_modified:
         value: false
+      defaults_yaml:
+        value: false
+      defaults_dict:
+        value: {}
+      dataset_name:
+        value: ""
 resources:
   timezone_config:
     config:

--- a/repositories/queries/pipelines.py
+++ b/repositories/queries/pipelines.py
@@ -4,6 +4,12 @@ from dagster.core.definitions.mode import ModeDefinition
 from repositories.capturas.resources import discord_webhook, timezone_config
 from repositories.libraries.basedosdados.solids import update_view
 from repositories.helpers.hooks import discord_message_on_failure, discord_message_on_success
+from repositories.queries.solids import (
+    update_materialized_view_on_redis,
+    create_table_if_not_exists,
+    delete_table_on_query_change,
+    insert_into_table_if_already_existed,
+)
 
 
 @discord_message_on_failure
@@ -16,3 +22,45 @@ from repositories.helpers.hooks import discord_message_on_failure, discord_messa
 )
 def update_view_on_bigquery():
     update_view()
+
+
+@discord_message_on_failure
+@discord_message_on_success
+@pipeline(mode_defs=[
+    ModeDefinition(
+        "dev", resource_defs={"discord_webhook": discord_webhook, "timezone_config": timezone_config}
+    ),
+],
+)
+def update_managed_materialized_views():
+    update_materialized_view_on_redis()
+
+
+@discord_message_on_failure
+@discord_message_on_success
+@pipeline(mode_defs=[
+    ModeDefinition(
+        "dev", resource_defs={"discord_webhook": discord_webhook, "timezone_config": timezone_config}
+    ),
+],
+)
+def materialize_view():
+
+    # Delete table if query has changed
+    # Steps:
+    # 1. Check if table exists
+    # 2. If exists, check if query has changed
+    # 3. If changed, delete table
+    done_1 = delete_table_on_query_change()
+
+    # Create table and run query if table does not exist
+    # Steps:
+    # - If table exists, return
+    # - If table does not exist, create table
+    already_existed = create_table_if_not_exists(last_step_done=done_1)
+
+    # Run query if table already existed
+    # Steps:
+    # - If table exists, run query
+    # - If table does not exist, return
+    insert_into_table_if_already_existed(already_existed=already_existed)

--- a/repositories/queries/sensors.py
+++ b/repositories/queries/sensors.py
@@ -1,5 +1,7 @@
 import os
 import time
+import yaml
+import datetime
 from pathlib import Path
 from google.cloud.storage.blob import Blob
 
@@ -7,7 +9,9 @@ from redis_pal import RedisPal
 from dagster import RunRequest, sensor, SensorExecutionContext
 
 from repositories.helpers.helpers import read_config
-from repositories.helpers.io import build_run_key, get_list_of_blobs, parse_filepath_to_tablename, parse_run_key
+from repositories.helpers.constants import constants
+from repositories.helpers.datetime import determine_whether_to_execute_or_not, convert_datetime_to_datetime_string
+from repositories.helpers.io import build_run_key, get_blob, get_list_of_blobs, parse_filepath_to_tablename, parse_run_key
 
 SENSOR_BUCKET = os.getenv("SENSOR_BUCKET", "rj-smtr-dev")
 VIEWS_PREFIX = os.getenv("VIEWS_PREFIX", "queries/views/")
@@ -23,7 +27,7 @@ def views_sensor(context: SensorExecutionContext):
     is triggered. This ensures BQ views are always up-to-date.
     """
     # Start RedisPal (we use that to check on deleted files)
-    rp: RedisPal = RedisPal(host="dagster-redis-master")
+    rp: RedisPal = RedisPal(host=constants.REDIS_HOST.value)
 
     # Get last modification time
     last_mtime = parse_run_key(context.last_run_key)[
@@ -103,3 +107,169 @@ def views_sensor(context: SensorExecutionContext):
 
                 # Yield a run request
                 yield RunRequest(run_key=run_key, run_config=config)
+
+
+@sensor(pipeline_name="update_managed_materialized_views", mode="dev")
+def materialized_views_update_sensor(context: SensorExecutionContext):
+    """Sensor for updating materialized views on file changes.
+
+    For every new or modified file, the pipeline `update_managed_materialized_views`
+    is triggered. This ensures BQ materialized views are always up-to-date.
+    """
+    # Start RedisPal (we use that to check on deleted files)
+    rp: RedisPal = RedisPal(host=constants.REDIS_HOST.value)
+
+    # Get last modification time
+    last_mtime = parse_run_key(context.last_run_key)[
+        1] if context.last_run_key else 0
+
+    # Get list of files
+    list_of_blobs: list = get_list_of_blobs(
+        MATERIALIZED_VIEWS_PREFIX, SENSOR_BUCKET)
+
+    # Get previous set of files from Redis
+    prev_set_of_blobs: set = rp.get("materialized_views_files_set")
+
+    # Parse current list of files to set
+    set_of_blobs: set = set([blob.name for blob in list_of_blobs])
+
+    # If we've cached a previous list of files
+    if prev_set_of_blobs is not None:
+
+        # Get deleted files
+        deleted: set = prev_set_of_blobs - set_of_blobs
+
+        # For every deleted file, delete corresponding view
+        blob_name: str = None
+        for blob_name in deleted:
+            if blob_name.endswith(".sql"):
+
+                # Set a run key so we can keep track of changes
+                run_key: str = build_run_key(
+                    "delete-materialized-" + blob_name, last_mtime)
+
+                # Load run configuration
+                config: dict = read_config(
+                    Path(__file__).parent / "materialized_views_update.yaml")
+
+                # Set inputs
+                config["solids"]["update_materialized_view_on_redis"]["inputs"]["blob_name"]["value"] = blob_name
+                config["solids"]["update_materialized_view_on_redis"]["inputs"]["cron_expression"]["value"] = ""
+                config["solids"]["update_materialized_view_on_redis"]["inputs"]["delete"]["value"] = True
+
+                # Yield a run request
+                yield RunRequest(run_key=run_key, run_config=config)
+
+    # Cache current file list
+    rp.set("materialized_views_files_set", set_of_blobs)
+
+    # Iterate over all YAML files
+    blob: Blob = None
+    for blob in list_of_blobs:
+        if blob.name.endswith(".yaml") or blob.name.endswith(".yml"):
+
+            # Get file's last modification timestamp
+            file_mtime = time.mktime(blob.updated.timetuple())
+
+            # If file has modified
+            if file_mtime > last_mtime:
+
+                # Extract query from file
+                materialized_view_config: dict = yaml.safe_load(
+                    blob.download_as_string().decode("utf-8"))
+
+                # Set a run key so we can keep track of changes
+                run_key: str = build_run_key(blob.name, file_mtime)
+
+                # Check if query has also changed
+                query_blob_name = blob.name.split(".y")[0] + ".sql"
+                query_blob = get_blob(query_blob_name, SENSOR_BUCKET)
+                if query_blob is not None and time.mktime(query_blob.updated.timetuple()) > last_mtime:
+                    query_modified = True
+                else:
+                    query_modified = False
+
+                # Load run configuration
+                config: dict = read_config(
+                    Path(__file__).parent / "materialized_views_update.yaml")
+
+                # Set inputs
+                config["solids"]["update_materialized_view_on_redis"]["inputs"]["blob_name"]["value"] = blob.name
+                config["solids"]["update_materialized_view_on_redis"]["inputs"][
+                    "cron_expression"]["value"] = materialized_view_config["scheduling"]["cron"]
+                config["solids"]["update_materialized_view_on_redis"]["inputs"]["delete"]["value"] = False
+                config["solids"]["update_materialized_view_on_redis"]["inputs"]["query_modified"]["value"] = query_modified
+
+                # Yield a run request
+                yield RunRequest(run_key=run_key, run_config=config)
+
+
+@sensor(pipeline_name="materialize_view", mode="dev")
+def materialized_views_execute_sensor(context: SensorExecutionContext):
+    """Sensor for executing materialized views based on cron expressions."""
+    # Start RedisPal (we use that to check cron expressions)
+    rp: RedisPal = RedisPal(host=constants.REDIS_HOST.value)
+
+    # Get managed materialized views
+    managed_materialized_views: dict = rp.get("managed_materialized_views")
+
+    # Get current timestamp
+    now = datetime.datetime.now()
+
+    # Iterate over all managed materialized views
+    for blob_name, view_config in managed_materialized_views.items():
+        if view_config["last_run"] is None or determine_whether_to_execute_or_not(view_config["cron_expression"], now, view_config["last_run"]):
+
+            # Load run configuration
+            config: dict = read_config(
+                Path(__file__).parent / "materialized_views_execute.yaml")
+
+            # Get query
+            blob: Blob = get_blob(blob_name.split(
+                ".y")[0] + ".sql", SENSOR_BUCKET)
+            query: str = blob.download_as_string().decode("utf-8")
+
+            # Extract table name from blob path
+            table_name: str = parse_filepath_to_tablename(
+                "/".join([n for n in blob.name.split(MATERIALIZED_VIEWS_PREFIX)[1].split("/") if n != ""]))
+
+            # Get query configs
+            blob: Blob = get_blob(blob_name, SENSOR_BUCKET)
+            query_config: dict = yaml.safe_load(
+                blob.download_as_string().decode("utf-8"))
+
+            # Checks if query is modified and then reset it on Redis
+            query_modified = view_config["query_modified"]
+            view_config["query_modified"] = False
+
+            # Get base configs
+            with open(str(Path(__file__).parent / "materialized_views_base_config.yaml"), "r") as f:
+                base_config: dict = yaml.safe_load(f)
+
+            # Set inputs
+            config["solids"]["delete_table_on_query_change"]["inputs"]["table_name"]["value"] = table_name
+            config["solids"]["delete_table_on_query_change"]["inputs"]["changed"]["value"] = query_modified
+            config["solids"]["create_table_if_not_exists"]["inputs"]["base_query"]["value"] = query
+            config["solids"]["create_table_if_not_exists"]["inputs"]["table_name"]["value"] = table_name
+            config["solids"]["create_table_if_not_exists"]["inputs"]["base_params"]["value"] = base_config
+            config["solids"]["create_table_if_not_exists"]["inputs"]["query_params"]["value"] = query_config
+            config["solids"]["create_table_if_not_exists"]["inputs"]["now"]["value"] = convert_datetime_to_datetime_string(
+                now)
+            config["solids"]["insert_into_table_if_already_existed"]["inputs"]["base_query"]["value"] = query
+            config["solids"]["insert_into_table_if_already_existed"]["inputs"]["table_name"]["value"] = table_name
+            config["solids"]["insert_into_table_if_already_existed"]["inputs"]["base_params"]["value"] = base_config
+            config["solids"]["insert_into_table_if_already_existed"]["inputs"]["query_params"]["value"] = query_config
+            config["solids"]["insert_into_table_if_already_existed"]["inputs"]["now"]["value"] = convert_datetime_to_datetime_string(
+                now)
+            config["solids"]["insert_into_table_if_already_existed"]["inputs"]["last_run"]["value"] = convert_datetime_to_datetime_string(
+                view_config["last_run"])
+
+            yield RunRequest(
+                run_key=build_run_key(blob_name, now),
+                run_config=config
+            )
+
+            view_config["last_run"] = now
+
+    # Update Redis with new last run times
+    rp.set("managed_materialized_views", managed_materialized_views)

--- a/repositories/queries/solids.py
+++ b/repositories/queries/solids.py
@@ -1,0 +1,137 @@
+import jinja2
+from dagster import solid
+from redis_pal import RedisPal
+
+from repositories.helpers.constants import constants
+from repositories.helpers.io import (
+    run_query,
+    check_if_table_exists,
+    insert_results_to_table
+)
+
+
+@solid
+def update_materialized_view_on_redis(context, blob_name: str, cron_expression: str, delete: bool, query_modified: bool):
+    rp = RedisPal(constants.REDIS_HOST.value)
+    materialized_views: dict = rp.get("managed_materialized_views")
+    materialized_views = materialized_views if materialized_views else {}
+    if query_modified:
+        context.log.info(f"Query has been modified!")
+    else:
+        context.log.info(f"Query has NOT been modified!")
+    if (delete and blob_name in materialized_views):
+        del materialized_views[blob_name]
+        context.log.info(f"Deleted materialized view {blob_name}")
+    elif (not delete):
+        if (blob_name in materialized_views):
+            materialized_views[blob_name]["cron_expression"] = cron_expression
+            materialized_views[blob_name]["query_modified"] = query_modified
+        else:
+            materialized_views[blob_name] = {
+                "cron_expression": cron_expression,
+                "last_run": None,
+                "query_modified": query_modified,
+            }
+        context.log.info(f"Updated materialized view {blob_name}")
+    else:
+        context.log.warning(
+            f"Materialized view {blob_name} does not exist, skipping...")
+    rp.set("managed_materialized_views", materialized_views)
+
+
+@solid
+def delete_table_on_query_change(context, table_name: str, changed: bool):
+    if check_if_table_exists(table_name) and changed:
+        context.log.info(f"Deleting table {table_name}")
+        context.log.info(f"Running query: DROP TABLE {table_name}")
+        run_query(f"DROP TABLE {table_name}")
+    else:
+        context.log.info(
+            f"Skipping table {table_name} as it does not exist or query hasn't changed")
+    return True
+
+
+@solid
+def create_table_if_not_exists(context, base_query: str, base_params: dict, query_params: dict, table_name: str, now: str, last_step_done: bool):
+    """Creates a table if it doesn't exist"""
+
+    # If table does not exist
+    if not check_if_table_exists(table_name):
+
+        # Get params
+        base_params = base_params["value"]  # Basic parameters
+        query_params = query_params["value"]  # Query parameters
+        custom_params = {
+            "date_range_start": "'{}'".format(query_params["backfill"]["start_timestamp"]),
+            "date_range_end": "'{}'".format(now)
+        }  # Backfill parameters
+
+        # Build query for data
+        template = jinja2.Template(base_query)
+        query = template.render(
+            **base_params, **query_params["parameters"], **custom_params)
+
+        # Build CREATE TABLE query
+        partition_by_type: str = query_params["partitioning"]["type"]
+        if partition_by_type.upper() != "DATE":
+            partition_by_period = query_params["partitioning"]["period"]
+        else:
+            partition_by_period = None
+        create_table_query = f"""
+        CREATE TABLE {table_name}
+            PARTITION BY {partition_by_type}({query_params["partitioning"]["column"]}{f", {partition_by_period}" if partition_by_period else ""})
+            AS
+            ({query})
+        """
+
+        # Run query
+        context.log.info(f"Running query: {create_table_query}")
+        run_query(create_table_query)
+        return False
+
+    # If table exists
+    else:
+        context.log.info(
+            f"Skipping table {table_name} as it already exists")
+        return True
+
+
+@solid
+def insert_into_table_if_already_existed(context, base_query: str, base_params: dict, query_params: dict, table_name: str, last_run: str, now: str, already_existed: bool):
+    """Creates a table if it doesn't exist"""
+
+    # If table already existed
+    if already_existed:
+
+        # Get params
+        base_params = base_params["value"]  # Basic parameters
+        query_params = query_params["value"]  # Query parameters
+        custom_params = {
+            "date_range_start": "'{}'".format(last_run),
+            "date_range_end": "'{}'".format(now)
+        }  # Backfill parameters
+
+        # Build query for data
+        template = jinja2.Template(base_query)
+        query = template.render(
+            **base_params, **query_params["parameters"], **custom_params)
+
+        # Execute query
+        context.log.info(f"Running query: {query}")
+        results = run_query(query)
+
+        # Insert results to table and check for errors
+        if (results.total_rows == 0):
+            context.log.warning(
+                f"No rows found for query, skipping...")
+        else:
+            errors = insert_results_to_table(results, table_name)
+            if errors:
+                context.log.error(f"Errors: {errors}")
+            else:
+                context.log.info(
+                    f"Inserted {results.total_rows} rows into {table_name}")
+
+    else:
+        context.log.info(
+            f"Skipping table {table_name} as has been created now")

--- a/repositories/queries/views.yaml
+++ b/repositories/queries/views.yaml
@@ -14,4 +14,4 @@ resources:
   discord_webhook:
     config:
       url: "{{ '' | env_override('QUERIES_DISCORD_WEBHOOK') }}"
-      success_cron: "00 08 * * *"
+      success_cron: "* * * * *"

--- a/repositories/repository.yaml
+++ b/repositories/repository.yaml
@@ -50,11 +50,15 @@ queries:
     - module: repositories.queries.pipelines
       objects:
         - update_view_on_bigquery
+        - update_managed_materialized_views
+        - materialize_view
 
   sensors:
     - module: repositories.queries.sensors
       objects:
         - views_sensor
+        - materialized_views_update_sensor
+        - materialized_views_execute_sensor
 
 maintenance:
   pipelines:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pandas==1.2.4
 traitlets==5.0.5
 redis-pal>=0.1.4
 sqlalchemy<=1.4.99
+pottery<=1.3.99

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ traitlets==5.0.5
 redis-pal>=0.1.4
 sqlalchemy<=1.4.99
 pottery<=1.3.99
+networkx<=2.6.99


### PR DESCRIPTION
Linkado a #53 

## Adiciona

- Sensor `materialized_views_update_sensor`: verifica por alterações nos YAMLs no `maestro-bq` e, quando existem, atualiza o cron no Redis. Caso, ao verificar uma alteração no YAML, também haja alteração no SQL, informa o Redis dessa mesma informação;
- Sensor `materialized_views_execute_sensor`: avalia os cron expressions de cada materialized view no Redis e executa caso seja o momento. Se o SQL foi alterado, dropa a tabela. Se a tabela não existe (ou foi dropada), cria a tabela com a query SQL e preenchendo com dados desde `backfill.start_timestamp` (do YAML) até o timestamp da run. Se a tabela não foi criada, realiza a query filtrando entre `date_range_start` e `date_range_end` (especificar na query)
- `repositories.helpers.constants.constants`: um objeto `enum.Enum` contendo constantes utilizadas em vários trechos do código. Para o momento, a única adicionada é o hostname do Redis, mantendo consistência em toda a codebase

**Obs:** ambos SQL e YAML devem ter o mesmo nome, somente com extensões diferentes!!!

## Atributos disponíveis para queries

- `run_key`: a chave montada no Dagster para essa execução
- `run_timestamp`: estampa de tempo dessa execução (exclusivo para cada execução de pipeline)
- `maestro_sha`: hash do commit mais recente na branch default do repositório maestro
- `maestro_bq_sha`: hash do commit mais recente na branch default do repositório maestro-bq
- `date_range_start`: início da janela de filtragem para backfill
  - Coincide com o `backfill.start_timestamp` do YAML na criação da tabela
  - Coincide com o timestamp da última execução nas outras execuções
- `date_range_end`: fim da janela de filtragem para backfill
  - Coincide com o timestamp do sensor (único para todas as RunRequests daquela execução do sensor)
- Tudo que estiver dentro da chave `parameters` do YAML, sem o prefixo `parameters.*`
  - Exemplo: no YAML -> `parameters.interval = 2`, na query -> `{{ interval }}`

## Exemplo de materialized view

- Arquivo de query em `maestro-bq/materialized_views/br_rj_riodejaneiro_brt_gps/materialized_registros_tratada.sql`:
```sql
WITH box AS (
  SELECT
    *
  FROM `rj-smtr.br_rj_riodejaneiro_geo.limites_geograficos_caixa`
)
SELECT
  *,
  {{ run_key }} AS run_key,
  {{ run_timestamp }} AS run_timestamp,
  {{ maestro_sha }} AS maestro_sha,
  {{ maestro_bq_sha }} AS maestro_bq_sha,
FROM `rj-smtr.br_rj_riodejaneiro_brt_gps.registros` 
WHERE DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) < {{ interval }}
AND timestamp_gps >= {{ date_range_start }}
AND timestamp_gps < {{ date_range_end }}
AND longitude BETWEEN (SELECT min_longitude FROM box) AND (SELECT max_longitude FROM box)
AND latitude BETWEEN (SELECT min_latitude FROM box) AND (SELECT max_latitude FROM box)
```

- Arquivo de configuração em `maestro-bq/materialized_views/br_rj_riodejaneiro_brt_gps/materialized_registros_tratada.yaml`:
```yaml
# Definição de taxa de atualização
scheduling:
  cron: "0/5 * * * *"

# Definição de particionamento
# - column: nome da coluna
# - type: deve ser um dos seguintes
#   * DATE (não exige período)
#   * DATE_TRUNC (exige período MONTH/YEAR)
#   * DATETIME_TRUNC (exige período DAY/HOUR/MONTH/YEAR)
#   * TIMESTAMP_TRUNC (exige período DAY/HOUR/MONTH/YEAR)
#   * <To-do> RANGE_BUCKET
#   * <To-do> GENERATE_ARRAY
# - period: período (conforme especificado acima)
partitioning:
  column: "timestamp_gps"
  type: "DATE"
  period: ""

# Parâmetros da query
parameters:
  interval: 2

# Parâmetros de backfill
backfill:
  # Formato %Y-%m-%d %H:%M:%S
  start_timestamp: "2021-01-01 00:00:00"
```

- Resultado: criação da tabela `br_rj_riodejaneiro_brt_gps.materialized_registros_tratada` que se materializa incrementalmente a cada 5 minutos e particionada diariamente em `timestamp_gps`