### PR TITLE
Aumenta performance de I/O com banco de dados

### DIFF
--- a/gke/citus/citus-master-deployment.yaml
+++ b/gke/citus/citus-master-deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: citus-master
+  name: citus-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: citus-master
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: citus-master
+    spec:
+      containers:
+        - name: citus
+          image: citusdata/citus:8.0.0
+          ports:
+            - containerPort: 5432
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: citus-secrets
+                  key: password
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: citus-secrets
+                  key: password
+          volumeMounts:
+            - name: storage
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - ./pg_healthcheck
+            initialDelaySeconds: 60
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: citus-master-pvc

--- a/gke/citus/citus-master-pvc.yaml
+++ b/gke/citus/citus-master-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: citus-master
+  name: citus-master-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/gke/citus/citus-master-service.yaml
+++ b/gke/citus/citus-master-service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: citus-master
+  labels:
+    app: citus-master
+spec:
+  selector:
+    app: citus-master
+  ports:
+    - port: 5432

--- a/gke/citus/citus-workers-service.yaml
+++ b/gke/citus/citus-workers-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: citus-workers
+  labels:
+    app: citus-workers
+spec:
+  selector:
+    app: citus-workers
+  clusterIP: None
+  ports:
+    - port: 5432

--- a/gke/citus/citus-workers-statefulset.yaml
+++ b/gke/citus/citus-workers-statefulset.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: citus-worker
+spec:
+  selector:
+    matchLabels:
+      app: citus-workers
+  serviceName: citus-workers
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: citus-workers
+    spec:
+      containers:
+        - name: citus-worker
+          image: citusdata/citus:8.0.0
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - if [ ${POD_IP} ]; then psql --host=citus-master --username=postgres --command="SELECT * from master_add_node('${HOSTNAME}.citus-workers', 5432);" ; fi
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: citus-secrets
+                  key: password
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: citus-secrets
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: wstorage
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - ./pg_healthcheck
+            initialDelaySeconds: 60
+  volumeClaimTemplates:
+    - metadata:
+        name: wstorage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 50Gi

--- a/repositories/maintenance/pipelines.py
+++ b/repositories/maintenance/pipelines.py
@@ -1,28 +1,32 @@
-from dagster import pipeline, PipelineRun
+from dagster import pipeline
 from dagster.core.definitions.mode import ModeDefinition
 
 from repositories.maintenance.solids import (
     get_compare_timestamp,
-    get_dagster_instance,
     get_runs,
-    filter_runs,
-    delete_runs,
+    filter_and_delete_runs,
 )
 from repositories.capturas.resources import discord_webhook, timezone_config
-from repositories.helpers.hooks import discord_message_on_failure, discord_message_on_success
+from repositories.helpers.hooks import (
+    discord_message_on_failure,
+    discord_message_on_success,
+)
 
 
 @discord_message_on_failure
 @discord_message_on_success
-@pipeline(mode_defs=[
-    ModeDefinition(
-        "dev", resource_defs={"discord_webhook": discord_webhook, "timezone_config": timezone_config}
-    ),
-],
+@pipeline(
+    mode_defs=[
+        ModeDefinition(
+            "dev",
+            resource_defs={
+                "discord_webhook": discord_webhook,
+                "timezone_config": timezone_config,
+            },
+        ),
+    ],
 )
 def wipe_history():
     compare_timestamp = get_compare_timestamp()
-    instance = get_dagster_instance()
-    all_runs = get_runs(instance)
-    runs_to_wipe = filter_runs(instance, all_runs, compare_timestamp)
-    delete_runs(instance, runs_to_wipe)
+    all_runs = get_runs()
+    filter_and_delete_runs(all_runs, compare_timestamp)

--- a/repositories/maintenance/schedules.py
+++ b/repositories/maintenance/schedules.py
@@ -1,23 +1,20 @@
 from pathlib import Path
 from datetime import datetime, time
 
-from dagster import daily_schedule, ScheduleExecutionContext
+from dagster import schedule, ScheduleExecutionContext
 from dagster.core.storage.event_log.schema import SqlEventLogStorageTable
 from dagster.core.storage.runs.schema import RunsTable, RunTagsTable, SnapshotsTable
 
 from repositories.helpers.helpers import read_config
 
 
-@daily_schedule(
-    pipeline_name='wipe_history',
-    start_date=datetime(2021, 1, 1),
-    name="wipe_history_daily",
-    execution_time=time(1, 30),
+@schedule(
+    cron_schedule="0 * * * *",
+    pipeline_name="wipe_history",
+    name="wipe_history_hourly",
     mode="dev",
     execution_timezone="America/Sao_Paulo",
 )
-def wipe_history_daily(context: ScheduleExecutionContext):
-    config = read_config(
-        Path(__file__).parent / "wipe_history.yaml"
-    )
+def wipe_history_hourly(context: ScheduleExecutionContext):
+    config = read_config(Path(__file__).parent / "wipe_history.yaml")
     return config

--- a/repositories/maintenance/solids.py
+++ b/repositories/maintenance/solids.py
@@ -1,59 +1,74 @@
+import time
 from datetime import datetime, timedelta
 
-from dagster import DagsterInstance
 from dagster import solid, SolidExecutionContext
 from dagster.core.definitions import InputDefinition
+from dagster.core.storage.pipeline_run import (
+    PipelineRunsFilter,
+    PipelineRunStatus,
+)
 
 from repositories.helpers.datetime import convert_unix_time_to_datetime
 
 
 @solid
-def get_dagster_instance(context) -> DagsterInstance:
-    return DagsterInstance.get()
+def get_runs(context: SolidExecutionContext):
+    return context.instance.get_runs(
+        filters=PipelineRunsFilter(
+            statuses=[
+                PipelineRunStatus.SUCCESS,
+                PipelineRunStatus.FAILURE,
+                PipelineRunStatus.CANCELED,
+            ]
+        )
+    )
 
 
 @solid
-def get_runs(context, instance: DagsterInstance):
-    return instance.get_runs()
-
-
-@solid
-def filter_runs(context, instance: DagsterInstance, runs, compare_timestamp: datetime):
-    filtered_runs = []
-    for run in runs:
-        run_stats = instance.get_run_stats(run.run_id)
+def filter_and_delete_runs(
+    context: SolidExecutionContext, runs, compare_timestamp: datetime
+):
+    instance = context.instance
+    total_runs = len(runs)
+    deleted_runs = 0
+    context.log.info(f"Collected {total_runs} runs")
+    tick_delay = 3000 / (total_runs + 1)  # Make it last 50 minutes
+    next_tick = time.time() + tick_delay
+    i = 0
+    while i < total_runs:
+        while time.time() < next_tick:
+            time.sleep(0.01)
+        run_stats = instance.get_run_stats(runs[i].run_id)
         if run_stats is None:
+            i += 1
+            next_tick += tick_delay
             continue
         launch_time = run_stats.launch_time
         if launch_time is None:
+            i += 1
+            next_tick += tick_delay
             continue
-        launch_time = convert_unix_time_to_datetime(
-            launch_time
-        )
+        launch_time = convert_unix_time_to_datetime(launch_time)
         if launch_time <= compare_timestamp:
-            filtered_runs.append(run)
-    return filtered_runs
-
-
-@solid
-def delete_runs(context, instance: DagsterInstance, runs):
-    context.log.info(f'Will delete {len(runs)} runs')
-    failed_runs = []
-    for run in runs:
-        try:
-            instance.delete_run(run.run_id)
-        except Exception as e:
-            failed_runs.append(run.run_id)
-    context.log.info(f'Deleted {len(runs) - len(failed_runs)} runs')
+            instance.delete_run(runs[i].run_id)
+            deleted_runs += 1
+        next_tick += tick_delay
+        i += 1
+    context.log.info(f"Deleted {deleted_runs} out of {total_runs} runs")
 
 
 @solid(
     input_defs=[
-        InputDefinition('seconds', int, default_value=0),
-        InputDefinition('minutes', int, default_value=0),
-        InputDefinition('hours', int, default_value=0),
-        InputDefinition('days', int, default_value=0),
+        InputDefinition("seconds", int, default_value=0),
+        InputDefinition("minutes", int, default_value=0),
+        InputDefinition("hours", int, default_value=0),
+        InputDefinition("days", int, default_value=0),
     ]
 )
-def get_compare_timestamp(context: SolidExecutionContext, seconds, minutes, hours, days) -> datetime:
-    return datetime.now() - timedelta(seconds=seconds, minutes=minutes, hours=hours, days=days)
+def get_compare_timestamp(
+    context: SolidExecutionContext, seconds, minutes, hours, days
+) -> datetime:
+    return datetime.now() - timedelta(
+        seconds=seconds, minutes=minutes, hours=hours, days=days
+    )
+

--- a/repositories/repository.yaml
+++ b/repositories/repository.yaml
@@ -71,4 +71,4 @@ maintenance:
   schedules:
     - module: repositories.maintenance.schedules
       objects:
-        - wipe_history_daily
+        - wipe_history_hourly


### PR DESCRIPTION
## Modificações
- Schedule `wipe_history_daily` passa a ser executado de hora em hora, tendo seu nome mudado para `wipe_history_hourly`
- Pipeline `wipe_history` agora dilui os deletes em um intervalo de 50 minutos, de modo a tentar não forçar operações intensivas no DB, que poderia falhar as capturas
- Adiciona-se um banco de dados no próprio Kubernetes Cluster, reduzindo gargalos de rede, com a extensão [Citus](https://www.citusdata.com/) para PostgreSQL, fazendo dele um banco de dados distribuído
- Os PVCs para o banco de dados serão alocados dinamicamente conforme a necessidade de armazenamento