### PR TITLE
Refatora o sensor do FTPS para partition-based schedule (daily)

### DIFF
--- a/repositories/capturas/br_rj_riodejaneiro_rdo/base.yaml
+++ b/repositories/capturas/br_rj_riodejaneiro_rdo/base.yaml
@@ -1,0 +1,17 @@
+resources:
+  basedosdados_config:
+    config:
+      table_id: brt_rdo40_registros
+      dataset_id: br_rj_riodejaneiro_rdo
+  timezone_config:
+    config:
+      timezone: "America/Sao_Paulo"
+  discord_webhook:
+    config:
+      url: "{{ '' | env_override('BRT_DISCORD_WEBHOOK') }}"
+      success_cron: "* * * * *"
+solids:
+  get_runs:
+    inputs:
+      execution_date:
+        value: ""

--- a/repositories/capturas/br_rj_riodejaneiro_rdo/registros.py
+++ b/repositories/capturas/br_rj_riodejaneiro_rdo/registros.py
@@ -1,93 +1,375 @@
+import os
+import re
+from pathlib import Path
+from datetime import datetime, timedelta
+
+import jinja2
+import pendulum
+import pandas as pd
+import basedosdados as bd
+from dateutil import parser
 from dagster import (
     solid,
     pipeline,
     ModeDefinition,
     PresetDefinition,
 )
-
-from pathlib import Path
+from dagster.experimental import DynamicOutputDefinition, DynamicOutput
 
 from repositories.capturas.resources import (
     timezone_config,
     discord_webhook,
 )
-from repositories.libraries.basedosdados.resources import (
-    basedosdados_config,
+from repositories.libraries.basedosdados.resources import basedosdados_config
+from repositories.helpers.datetime import convert_datetime_to_unix_time
+from repositories.helpers.helpers import read_config
+from repositories.helpers.hooks import (
+    discord_message_on_failure,
+    discord_message_on_success,
+    redis_keepalive_on_failure,
+    redis_keepalive_on_succes,
 )
-from repositories.helpers.hooks import discord_message_on_failure, discord_message_on_success, redis_keepalive_on_failure, redis_keepalive_on_succes
-from repositories.capturas.solids import (
-    get_file_from_storage,
-    upload_file_to_storage,
-    parse_file_path_and_partitions,
-    save_treated_local,
-    download_file_from_ftp,
-)
+from repositories.helpers.io import connect_ftp
 from repositories.libraries.basedosdados.solids import (
-    upload_to_bigquery,
+    append_to_bigquery,
+    create_table_bq,
 )
-from repositories.libraries.pandas.solids import (
-    load_and_reindex_csv,
-    add_timestamp,
-)
+from repositories.helpers.storage import StoragePlus
+
+ALLOWED_FOLDERS = ["SPPO", "STPL"]
+FTPS_DIRECTORY = os.getenv("FTPS_DATA", "/opt/dagster/app/data/FTPS_DATA")
+
+#
+# Previous solids, now functions
+#
+def fn_download_file_from_ftp(ftp_path: str, local_path: str) -> None:
+    """Downloads a file from FTP to the local storage"""
+    Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+    ftp_client = connect_ftp(
+        os.getenv("FTPS_HOST"), os.getenv("FTPS_USERNAME"), os.getenv("FTPS_PWD")
+    )
+    ftp_client.retrbinary("RETR " + ftp_path, open(local_path, "wb").write)
+    ftp_client.quit()
 
 
-@solid
-def divide_columns(context, df, cols_to_divide=None, value=100):
+def fn_parse_file_path_and_partitions(context, bucket_path):
+
+    # Parse bucket to get mode, dataset_id, table_id and filename
+    path_list = bucket_path.split("/")
+    dataset_id = path_list[1]
+    table_id = path_list[2]
+    filename = path_list[-1].split(".")[0]
+    filetype = path_list[-1].split(".")[1]
+
+    # Parse bucket to get partitions
+    partitions = re.findall("\/([^\/]*?)=(.*?)(?=\/)", bucket_path)
+    partitions = "/".join(["=".join([field for field in item]) for item in partitions])
+
+    # Get data folder from environment variable
+    data_folder = os.getenv("DATA_FOLDER", "data")
+
+    folder = f"{os.getcwd()}/{data_folder}/{{mode}}/{dataset_id}/{table_id}/"
+    file_path = f"{folder}/{partitions}/{filename}.{{filetype}}"
+    context.log.info(f"creating file path {file_path}")
+
+    return filename, filetype, file_path, partitions
+
+
+def fn_upload_file_to_storage(
+    context, file_path, partitions=None, mode="raw", table_id=None
+):
+
+    # Upload to storage
+    # If not specific table_id, use resource one
+    if not table_id:
+        table_id = context.resources.basedosdados_config["table_id"]
+    dataset_id = context.resources.basedosdados_config["dataset_id"]
+
+    st = bd.Storage(table_id=table_id, dataset_id=dataset_id)
+
+    context.log.debug(
+        f"Uploading file {file_path} to mode {mode} with partitions {partitions}"
+    )
+    st.upload(path=file_path, mode=mode, partitions=partitions, if_exists="replace")
+
+    return True
+
+
+def fn_get_file_from_storage(
+    context,
+    file_path,
+    filename,
+    partitions,
+    mode="raw",
+    filetype="xlsx",
+    uploaded=True,
+    table_id=None,
+):
+
+    # Download from storage
+    # If not specific table_id, use resource one
+    if not table_id:
+        table_id = context.resources.basedosdados_config["table_id"]
+    dataset_id = context.resources.basedosdados_config["dataset_id"]
+
+    _file_path = file_path.format(mode=mode, filetype=filetype)
+
+    st = StoragePlus(table_id=table_id, dataset_id=dataset_id)
+    context.log.debug(f"File path: {_file_path}")
+    context.log.debug(f"filename: {filename}")
+    context.log.debug(f"partition: {partitions}")
+    context.log.debug(f"mode: {mode}")
+    st.download(
+        filename=filename + "." + filetype,
+        file_path=_file_path,
+        partitions=partitions,
+        mode=mode,
+        if_exists="replace",
+    )
+    return _file_path
+
+
+def fn_load_and_reindex_csv(
+    file_path: str, read_csv_kwargs: dict, reindex_kwargs: dict
+):
+    # Rearrange columns
+    # df = pd.read_csv(file_path, delimiter=delimiter,
+    #                  skiprows=header_lines,
+    #                  names=original_header,
+    #                  index_col=False)
+    df = pd.read_csv(file_path, **read_csv_kwargs)
+    df = df.reindex(**reindex_kwargs)
+    return df
+
+
+def fn_add_timestamp(context, df):
+    timezone = context.resources.timezone_config["timezone"]
+    timestamp_captura = pd.to_datetime(pendulum.now(timezone).isoformat())
+    df["timestamp_captura"] = timestamp_captura
+    context.log.debug(", ".join(list(df.columns)))
+
+    return df
+
+
+def fn_divide_columns(df, cols_to_divide=None, value=100):
     if cols_to_divide:
         # Divide columns by value
-        df[cols_to_divide] = df[cols_to_divide].apply(
-            lambda x: x/value, axis=1)
+        df[cols_to_divide] = df[cols_to_divide].apply(lambda x: x / value, axis=1)
     return df
+
+
+def fn_upload_to_bigquery(
+    context,
+    file_paths,
+    partitions,
+    modes=["raw", "staging"],
+    table_config="replace",
+    publish_config="pass",
+    is_init=False,
+    table_id=None,
+):
+    if is_init:
+        # Only available for mode staging
+        try:
+            idx = modes.index("staging")
+            create_table_bq(
+                context,
+                file_paths[idx],
+                table_config=table_config,
+                publish_config=publish_config,
+                table_id=table_id,
+            )
+        except ValueError:
+            raise RuntimeError("Publishing table outside staging mode")
+    else:
+        append_to_bigquery(
+            context, file_paths, partitions, modes=modes, table_id=table_id
+        )
+
+
+def fn_save_treated_local(df, file_path, mode="staging"):
+
+    _file_path = file_path.format(mode=mode, filetype="csv")
+    Path(_file_path).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(_file_path, index=False)
+
+    return _file_path
+
+
+@solid(output_defs=[DynamicOutputDefinition(dict)])
+def get_runs(context, execution_date):
+    execution_date = datetime.strptime(execution_date, "%Y-%m-%d")
+    now = execution_date + timedelta(hours=11, minutes=30)
+    this_time_yesterday = now - timedelta(days=1)
+    min_timestamp = convert_datetime_to_unix_time(this_time_yesterday)
+    max_timestamp = convert_datetime_to_unix_time(now)
+    context.log.info(f"{execution_date} of type {type(execution_date)}")
+    ftp_client = connect_ftp(
+        os.getenv("FTPS_HOST"), os.getenv("FTPS_USERNAME"), os.getenv("FTPS_PWD")
+    )
+
+    # Change to working directory
+    ftp_client.cwd("/")
+    for folder in ftp_client.mlsd():
+
+        # Config yaml file will be folder_fileprefix.yaml
+        if folder[1]["type"] == "dir" and folder[0] in ALLOWED_FOLDERS:
+            # CWD to folder
+            context.log.info(f"Entering folder {folder[0]}")
+            folder_name = folder[0].lower()
+
+            # Read file list
+            for filepath in ftp_client.mlsd(folder_name):
+                filename = filepath[0]
+                fileprefix = filename.split("_")[0].lower()
+                timestamp = filepath[1]["modify"]
+                file_mtime = datetime.timestamp(parser.parse(timestamp))
+
+                if file_mtime >= min_timestamp and file_mtime < max_timestamp:
+
+                    # Download file to local folder
+                    try:
+                        config = read_config(
+                            Path(__file__).parent / f"{folder_name}_{fileprefix}.yaml"
+                        )
+                        table_id = config["resources"]["basedosdados_config"]["config"][
+                            "table_id"
+                        ]
+                        date = tuple(re.findall("\d+", filename))
+                        ano = date[2][:4]
+                        mes = date[2][4:6]
+                        dia = date[2][6:]
+                        relative_filepath = Path(
+                            "raw/br_rj_riodejaneiro_rdo",
+                            table_id,
+                            f"ano={ano}",
+                            f"mes={mes}",
+                            f"dia={dia}",
+                        )
+                        local_filepath = Path(FTPS_DIRECTORY, relative_filepath)
+                        Path(local_filepath).mkdir(parents=True, exist_ok=True)
+
+                        ftp_path = str(Path(folder_name, filename))
+                        local_path = str(Path(local_filepath, filename))
+
+                        # Run pipeline
+                        config["solids"]["download_file_from_ftp"]["inputs"] = {
+                            "ftp_path": {"value": ftp_path},
+                            "local_path": {"value": local_path},
+                        }
+                        config["solids"]["parse_file_path_and_partitions"]["inputs"][
+                            "bucket_path"
+                        ]["value"] = f"{relative_filepath}/{filename}"
+                        config["solids"]["upload_file_to_storage"] = {
+                            "inputs": {"file_path": {"value": local_path}}
+                        }
+                        yield DynamicOutput(
+                            config, mapping_key=f"{folder_name}_{fileprefix}"
+                        )
+
+                    except jinja2.TemplateNotFound as err:
+                        context.log.warning(
+                            f"Config file for file {filename} was not found. Skipping file."
+                        )
+                        context.log.warning(f"{Path(__file__).parent}")
+                ftp_client.cwd("/")
+        else:
+            context.log.warning(
+                f"Skipping file {folder[0]} since it is not inside a folder"
+            )
+            continue
+
+
+@solid(required_resource_keys={"timezone_config", "basedosdados_config"},)
+def execute_run(context, run_config: dict):
+
+    # Get file from FTPS and save it locally
+    ftp_path = run_config["solids"]["download_file_from_ftp"]["inputs"]["ftp_path"][
+        "value"
+    ]
+    local_path = run_config["solids"]["download_file_from_ftp"]["inputs"]["local_path"][
+        "value"
+    ]
+    fn_download_file_from_ftp(ftp_path, local_path)
+
+    # Parse file path and get partitions
+    bucket_path = run_config["solids"]["parse_file_path_and_partitions"]["inputs"][
+        "bucket_path"
+    ]["value"]
+    filename, filetype, file_path, partitions = fn_parse_file_path_and_partitions(
+        context, bucket_path
+    )
+
+    # Upload file to GCS
+    uploaded = fn_upload_file_to_storage(context, local_path, partitions)
+
+    # Get file from GCS
+    raw_file_path = fn_get_file_from_storage(
+        context,
+        file_path=file_path,
+        filename=filename,
+        partitions=partitions,
+        filetype=filetype,
+        uploaded=uploaded,
+    )
+
+    # Extract, load and transform
+    try:
+        read_csv_kwargs = run_config["solids"]["load_and_reindex_csv"]["config"][
+            "read_csv_kwargs"
+        ]
+    except:
+        context.log.warning(
+            f"Error reading read_csv_kwargs config file for {filename} in folder {file_path}. Skipping file."
+        )
+        read_csv_kwargs = None
+    try:
+        reindex_kwargs = run_config["solids"]["load_and_reindex_csv"]["config"][
+            "reindex_kwargs"
+        ]
+    except:
+        context.log.warning(
+            f"Error reading reindex_kwargs config file for {filename} in folder {file_path}. Skipping file."
+        )
+        reindex_kwargs = None
+    treated_data = fn_load_and_reindex_csv(
+        raw_file_path, read_csv_kwargs=read_csv_kwargs, reindex_kwargs=reindex_kwargs
+    )
+    treated_data = fn_add_timestamp(context, treated_data)
+    try:
+        cols_to_divide = run_config["solids"]["divide_columns"]["inputs"][
+            "cols_to_divide"
+        ]["value"]
+    except:
+        context.log.warning(
+            f"No cols_to_divide was found in config file. Using default cols_to_divide."
+        )
+        cols_to_divide = None
+    treated_data = fn_divide_columns(treated_data, cols_to_divide)
+
+    # Save treated file locally
+    treated_file_path = fn_save_treated_local(treated_data, file_path)
+
+    # Upload treated to BigQuery
+    modes = run_config["solids"]["upload_to_bigquery"]["inputs"]["modes"]["value"]
+    fn_upload_to_bigquery(context, [treated_file_path], partitions, modes=modes)
 
 
 @discord_message_on_failure
 @discord_message_on_success
 @pipeline(
-    preset_defs=[
-        PresetDefinition.from_files(
-            "BRT_RDO_40",
-            config_files=[str(Path(__file__).parent /
-                              "brt_rdo40_registros.yaml")],
-            mode="dev",
-        ),
-        PresetDefinition.from_files(
-            "Onibus_RDO_40",
-            config_files=[str(Path(__file__).parent /
-                              "onibus_rdo40_registros.yaml")],
-            mode="dev",
-        ),
-        PresetDefinition.from_files(
-            "RDO5",
-            config_files=[str(Path(__file__).parent / "rdo5_registros.yaml")],
-            mode="dev",
-        )
-    ],
     mode_defs=[
         ModeDefinition(
-            "dev", resource_defs={"basedosdados_config": basedosdados_config,
-                                  "timezone_config": timezone_config,
-                                  "discord_webhook": discord_webhook}
+            "dev",
+            resource_defs={
+                "basedosdados_config": basedosdados_config,
+                "timezone_config": timezone_config,
+                "discord_webhook": discord_webhook,
+            },
         ),
     ],
-    # tags={"dagster/priority": "-1"}
 )
 def br_rj_riodejaneiro_rdo_registros():
 
-    # Get file from FTPS and save it locally
-    download_file_from_ftp()
-
-    filename, filetype, file_path, partitions = parse_file_path_and_partitions()
-
-    uploaded = upload_file_to_storage(partitions=partitions)
-    raw_file_path = get_file_from_storage(file_path=file_path, filename=filename,
-                                          partitions=partitions, filetype=filetype,
-                                          uploaded=uploaded)
-
-    # Extract, load and transform
-    treated_data = load_and_reindex_csv(raw_file_path)
-    treated_data = add_timestamp(treated_data)
-    treated_data = divide_columns(treated_data)
-
-    treated_file_path = save_treated_local(treated_data, file_path)
-
-    upload_to_bigquery([treated_file_path], partitions)
+    runs = get_runs()
+    runs.map(execute_run)

--- a/repositories/capturas/schedules.py
+++ b/repositories/capturas/schedules.py
@@ -67,3 +67,19 @@ def br_rj_riodejaneiro_sigmob_data(date):
     }
 
     return config
+
+
+@daily_schedule(
+    pipeline_name="br_rj_riodejaneiro_rdo_registros",
+    start_date=datetime(2021, 1, 1),
+    name="ftps_schedule",
+    execution_time=time(11, 30),
+    mode="dev",
+    execution_timezone="America/Sao_Paulo",
+)
+def ftps_schedule(date):
+    config = read_config(Path(__file__).parent / "br_rj_riodejaneiro_rdo/base.yaml")
+    config["solids"]["get_runs"]["inputs"]["execution_date"]["value"] = date.strftime(
+        "%Y-%m-%d"
+    )
+    return config

--- a/repositories/capturas/sensors.py
+++ b/repositories/capturas/sensors.py
@@ -10,7 +10,14 @@ from datetime import datetime
 
 from repositories.helpers.helpers import read_config
 from repositories.helpers.logging import logger
-from repositories.helpers.io import get_list_of_files, build_run_key, parse_run_key, connect_ftp, get_list_of_blobs, filter_blobs_by_modification_time
+from repositories.helpers.io import (
+    get_list_of_files,
+    build_run_key,
+    parse_run_key,
+    connect_ftp,
+    get_list_of_blobs,
+    filter_blobs_by_modification_time,
+)
 
 FTPS_DIRECTORY = os.getenv("FTPS_DATA", "/opt/dagster/app/data/FTPS_DATA")
 SENSOR_BUCKET = os.getenv("SENSOR_BUCKET", "rj-smtr-dev")
@@ -21,103 +28,118 @@ ALLOWED_FOLDERS = ["SPPO", "STPL"]
 
 @sensor(pipeline_name="br_rj_riodejaneiro_gtfs_planned_feed", mode="dev")
 def gtfs_sensor(context):
-    last_mtime = parse_run_key(context.last_run_key)[
-        1] if context.last_run_key else 0
+    last_mtime = parse_run_key(context.last_run_key)[1] if context.last_run_key else 0
 
     for blob in filter_blobs_by_modification_time(
-        get_list_of_blobs(GTFS_BLOBS_PREFIX, SENSOR_BUCKET, mode="staging"), last_mtime, after=True,
+        get_list_of_blobs(GTFS_BLOBS_PREFIX, SENSOR_BUCKET, mode="staging"),
+        last_mtime,
+        after=True,
     ):
-        run_key: str = build_run_key(
-            blob.name, time.mktime(blob.updated.timetuple()))
+        run_key: str = build_run_key(blob.name, time.mktime(blob.updated.timetuple()))
 
         # Parse dataset_id and table_id
-        path_list: list = [n for n in blob.name.split(
-            GTFS_BLOBS_PREFIX)[1].split("/") if n != ""]
+        path_list: list = [
+            n for n in blob.name.split(GTFS_BLOBS_PREFIX)[1].split("/") if n != ""
+        ]
         dataset_id: str = path_list[0]
         table_id: str = path_list[1]
 
         # Set run configs
         config: dict = read_config(
-            Path(__file__).parent / f'{dataset_id}/{table_id}.yaml')
-        config['solids']['save_blob_to_tempfile'] = {'inputs': {'blob_path': {
-            'value': blob.name}, 'bucket_name': {'value': SENSOR_BUCKET}}}
-        config['solids']['create_gtfs_version_partition'] = {'inputs': {'original_filepath': {
-            'value': blob.name}, 'bucket_name': {'value': SENSOR_BUCKET}}}
-        config['solids']['upload_blob_to_storage'] = {'inputs': {'blob_path': {
-            'value': blob.name}, 'bucket_name': {'value': SENSOR_BUCKET}}}
-        config['resources']['basedosdados_config'] = {
-            "config": {"dataset_id": dataset_id, "table_id": table_id}}
+            Path(__file__).parent / f"{dataset_id}/{table_id}.yaml"
+        )
+        config["solids"]["save_blob_to_tempfile"] = {
+            "inputs": {
+                "blob_path": {"value": blob.name},
+                "bucket_name": {"value": SENSOR_BUCKET},
+            }
+        }
+        config["solids"]["create_gtfs_version_partition"] = {
+            "inputs": {
+                "original_filepath": {"value": blob.name},
+                "bucket_name": {"value": SENSOR_BUCKET},
+            }
+        }
+        config["solids"]["upload_blob_to_storage"] = {
+            "inputs": {
+                "blob_path": {"value": blob.name},
+                "bucket_name": {"value": SENSOR_BUCKET},
+            }
+        }
+        config["resources"]["basedosdados_config"] = {
+            "config": {"dataset_id": dataset_id, "table_id": table_id}
+        }
 
         yield RunRequest(run_key=run_key, run_config=config)
 
 
-@sensor(pipeline_name="br_rj_riodejaneiro_rdo_registros", mode="dev")
-def ftps_sensor(context):
-    last_mtime = float(context.cursor) if context.cursor else 0
-    logger.debug(f"Current cursor: {last_mtime}")
-    max_mtime = last_mtime + 259200
-    next_mtime = max_mtime
-    ftp_client = connect_ftp(os.getenv("FTPS_HOST"), os.getenv(
-        "FTPS_USERNAME"), os.getenv("FTPS_PWD"))
+# @sensor(pipeline_name="br_rj_riodejaneiro_rdo_registros", mode="dev")
+# def ftps_sensor(context):
+#     last_mtime = float(context.cursor) if context.cursor else 0
+#     logger.debug(f"Current cursor: {last_mtime}")
+#     max_mtime = last_mtime + 259200
+#     next_mtime = max_mtime
+#     ftp_client = connect_ftp(os.getenv("FTPS_HOST"), os.getenv(
+#         "FTPS_USERNAME"), os.getenv("FTPS_PWD"))
 
-    # Change to working directory
-    ftp_client.cwd('/')
-    for folder in ftp_client.mlsd():
+#     # Change to working directory
+#     ftp_client.cwd('/')
+#     for folder in ftp_client.mlsd():
 
-        # Config yaml file will be folder_fileprefix.yaml
-        if folder[1]['type'] == 'dir' and folder[0] in ALLOWED_FOLDERS:
-            # CWD to folder
-            logger.info(f"Entering folder {folder[0]}")
-            folder_name = folder[0].lower()
+#         # Config yaml file will be folder_fileprefix.yaml
+#         if folder[1]['type'] == 'dir' and folder[0] in ALLOWED_FOLDERS:
+#             # CWD to folder
+#             logger.info(f"Entering folder {folder[0]}")
+#             folder_name = folder[0].lower()
 
-            # Read file list
-            for filepath in ftp_client.mlsd(folder_name):
-                filename = filepath[0]
-                fileprefix = filename.split('_')[0].lower()
-                timestamp = filepath[1]['modify']
-                file_mtime = datetime.timestamp(parser.parse(timestamp))
+#             # Read file list
+#             for filepath in ftp_client.mlsd(folder_name):
+#                 filename = filepath[0]
+#                 fileprefix = filename.split('_')[0].lower()
+#                 timestamp = filepath[1]['modify']
+#                 file_mtime = datetime.timestamp(parser.parse(timestamp))
 
-                if file_mtime < max_mtime and file_mtime > last_mtime:
-                    # the run key should include mtime if we want to kick off new runs based on file modifications
-                    run_key = build_run_key(filename, file_mtime)
+#                 if file_mtime < max_mtime and file_mtime > last_mtime:
+#                     # the run key should include mtime if we want to kick off new runs based on file modifications
+#                     run_key = build_run_key(filename, file_mtime)
 
-                    # Download file to local folder
-                    try:
-                        config = read_config(Path(
-                            __file__).parent / f'br_rj_riodejaneiro_rdo/{folder_name}_{fileprefix}.yaml')
-                        table_id = config['resources']['basedosdados_config']['config']['table_id']
-                        date = tuple(re.findall("\d+", filename))
-                        ano = date[2][:4]
-                        mes = date[2][4:6]
-                        dia = date[2][6:]
-                        relative_filepath = Path(
-                            'raw/br_rj_riodejaneiro_rdo', table_id, f'ano={ano}', f'mes={mes}', f'dia={dia}')
-                        local_filepath = Path(
-                            FTPS_DIRECTORY, relative_filepath)
-                        Path(local_filepath).mkdir(parents=True, exist_ok=True)
+#                     # Download file to local folder
+#                     try:
+#                         config = read_config(Path(
+#                             __file__).parent / f'br_rj_riodejaneiro_rdo/{folder_name}_{fileprefix}.yaml')
+#                         table_id = config['resources']['basedosdados_config']['config']['table_id']
+#                         date = tuple(re.findall("\d+", filename))
+#                         ano = date[2][:4]
+#                         mes = date[2][4:6]
+#                         dia = date[2][6:]
+#                         relative_filepath = Path(
+#                             'raw/br_rj_riodejaneiro_rdo', table_id, f'ano={ano}', f'mes={mes}', f'dia={dia}')
+#                         local_filepath = Path(
+#                             FTPS_DIRECTORY, relative_filepath)
+#                         Path(local_filepath).mkdir(parents=True, exist_ok=True)
 
-                        ftp_path = str(Path(folder_name, filename))
-                        local_path = str(Path(local_filepath, filename))
+#                         ftp_path = str(Path(folder_name, filename))
+#                         local_path = str(Path(local_filepath, filename))
 
-                        # Run pipeline
-                        config['solids']['download_file_from_ftp']['inputs'] = {
-                            'ftp_path': {'value': ftp_path}, 'local_path': {'value': local_path}}
-                        config['solids']['parse_file_path_and_partitions']['inputs'][
-                            'bucket_path']['value'] = f'{relative_filepath}/{filename}'
-                        config['solids']['upload_file_to_storage'] = {"inputs": {
-                            "file_path": {"value": local_path}}}
-                        yield RunRequest(run_key=run_key, run_config=config)
+#                         # Run pipeline
+#                         config['solids']['download_file_from_ftp']['inputs'] = {
+#                             'ftp_path': {'value': ftp_path}, 'local_path': {'value': local_path}}
+#                         config['solids']['parse_file_path_and_partitions']['inputs'][
+#                             'bucket_path']['value'] = f'{relative_filepath}/{filename}'
+#                         config['solids']['upload_file_to_storage'] = {"inputs": {
+#                             "file_path": {"value": local_path}}}
+#                         yield RunRequest(run_key=run_key, run_config=config)
 
-                    except jinja2.TemplateNotFound as err:
-                        logger.warning(
-                            f"Config file for file {filename} was not found. Skipping file.")
+#                     except jinja2.TemplateNotFound as err:
+#                         logger.warning(
+#                             f"Config file for file {filename} was not found. Skipping file.")
 
-                next_mtime = min(file_mtime, max_mtime)
-                ftp_client.cwd('/')
-        else:
-            logger.warning(
-                f"Skipping file {folder[0]} since it is not inside a folder")
-            continue
+#                 next_mtime = min(file_mtime, max_mtime)
+#                 ftp_client.cwd('/')
+#         else:
+#             logger.warning(
+#                 f"Skipping file {folder[0]} since it is not inside a folder")
+#             continue
 
-        logger.debug(f"Setting cursor to {next_mtime}")
-        context.update_cursor(str(next_mtime))
+#         logger.debug(f"Setting cursor to {next_mtime}")
+#         context.update_cursor(str(next_mtime))

--- a/repositories/repository.yaml
+++ b/repositories/repository.yaml
@@ -6,6 +6,7 @@ capturas:
         - br_rj_riodejaneiro_brt_gps_registros
         - br_rj_riodejaneiro_onibus_gps_registros
         - br_rj_riodejaneiro_sigmob_data
+        - ftps_schedule
 
   pipelines:
     - module: repositories.capturas.br_rj_riodejaneiro_stpl_gps.registros
@@ -36,7 +37,6 @@ capturas:
     - module: repositories.capturas.sensors
       objects:
         - gtfs_sensor
-        - ftps_sensor
 
 analises:
   schedules:


### PR DESCRIPTION
## Mudanças
- Exclui (comentado) o `ftps_sensor`
- Adiciona `ftps_schedule`, que executa diariamente às 11h30 (horário em que, na grande maioria dos casos, os arquivos já estão enviados no servidor FTPS)
  - Procura por arquivos na faixa do dia anterior às 11h30 até 11h30 do dia da run
  - Para cada arquivo, gera uma configuração da run baseado no tipo (RDOV, RHO, SPPO, etc.)
  - Para cada config, lança um sólido `execute_run`, que faz todo o pipeline igual anteriormente
  - Em caso de falha (FTPS tende a falhar a conexão e dar timeout com certa frequência) pode tentar novamente por 3 vezes, com cooldown de 30 segundos
  - Permite backfill e independe da última run_key para verificar sua execução