### PR TITLE
Adiciona ID único na mapping key do `ftps_schedule`

### DIFF
--- a/repositories/capturas/br_rj_riodejaneiro_rdo/registros.py
+++ b/repositories/capturas/br_rj_riodejaneiro_rdo/registros.py
@@ -1,5 +1,6 @@
 import os
 import re
+import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 
@@ -262,7 +263,8 @@ def get_runs(context, execution_date):
                             "inputs": {"file_path": {"value": local_path}}
                         }
                         yield DynamicOutput(
-                            config, mapping_key=f"{folder_name}_{fileprefix}"
+                            config,
+                            mapping_key=f"{folder_name}_{fileprefix}_{uuid.uuid4()}",
                         )
 
                     except jinja2.TemplateNotFound as err:


### PR DESCRIPTION
Como o horário do upload dos arquivos é inconstante, algumas vezes um scheduler pode executar dados do dia anterior, o que geraria keys duplicadas.