### PR TITLE
Adiciona timeout nos requests do Sigmob e redireciona as exceptions para o canal do Discord antes do raise

### DIFF
--- a/repositories/helpers/constants.py
+++ b/repositories/helpers/constants.py
@@ -13,3 +13,5 @@ class constants(Enum):
     MAESTRO_BQ_REPOSITORY = "RJ-SMTR/maestro-bq"
     MAESTRO_BQ_DEFAULT_BRANCH = "master"
     CRITICAL_DISCORD_WEBHOOK = getenv("CRITICAL_DISCORD_WEBHOOK", "")
+    SIGMOB_GET_REQUESTS_TIMEOUT = 3600  # 1 hour
+


### PR DESCRIPTION
## Motivações

- Pipelines que ficavam em execução por tempo indefinido devido ao timeout
- Caso as pipelines falhassem, não havia indicação do motivo e era difícil de rastrear (#127)

## Modificações

- Adiciona um timeout (coloquei 1h/request) no GET request
  - Configurável em `repositories.helpers.constants.constants.SIGMOB_GET_REQUESTS_TIMEOUT`
- Adiciona o `log_critical` com a pilha do `raise` para