### PR TITLE
[SIGMOB] Fix publish.sql

### DIFF
--- a/bases/br_rj_riodejaneiro_sigmob/calendar/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/calendar/publish.sql
@@ -24,4 +24,4 @@ SELECT
 SAFE_CAST(service_id AS STRING) service_id,
 REPLACE(content,"None","") content,
 SAFE_CAST(data_versao AS STRING) data_versao
-from rj-smtr.br_rj_riodejaneiro_sigmob_staging.calendar as t
+from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.calendar as t

--- a/bases/br_rj_riodejaneiro_sigmob/frota_determinada/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/frota_determinada/publish.sql
@@ -24,4 +24,4 @@ SELECT
 SAFE_CAST(route_id AS STRING) route_id,
 REPLACE(content,"None","") content,
 SAFE_CAST(data_versao AS STRING) data_versao
-from rj-smtr.br_rj_riodejaneiro_sigmob_staging.frota_determinada as t
+from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.frota_determinada as t

--- a/bases/br_rj_riodejaneiro_sigmob/stop_details/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/stop_details/publish.sql
@@ -24,4 +24,4 @@ SELECT
 SAFE_CAST(stop_id AS STRING) stop_id,
 REPLACE(content,"None","") content,
 SAFE_CAST(data_versao AS STRING) data_versao
-from rj-smtr.br_rj_riodejaneiro_sigmob_staging.stop_details as t
+from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.stop_details as t


### PR DESCRIPTION
Para os endpoints novos adicionados, os arquivos publish.sql estão apontando para `rj-smtr` como origem das tabelas, mas deveriam apontar para `rj-smtr-staging`
Quick fix