### PR TITLE
[SIGMOB] Fix: data_versao com tipo DATE nos SAFE_CASTs

### DIFF
--- a/bases/br_rj_riodejaneiro_sigmob/agency/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/agency/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.agency AS
 SELECT 
 SAFE_CAST(agency_id AS STRING) agency_id,
 REPLACE(content,"None","") content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.agency as t

--- a/bases/br_rj_riodejaneiro_sigmob/calendar/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/calendar/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.calendar AS
 SELECT 
 SAFE_CAST(service_id AS STRING) service_id,
 REPLACE(content,"None","") content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.calendar as t

--- a/bases/br_rj_riodejaneiro_sigmob/frota_determinada/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/frota_determinada/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.frota_determinada AS
 SELECT 
 SAFE_CAST(route_id AS STRING) route_id,
 REPLACE(content,"None","") content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.frota_determinada as t

--- a/bases/br_rj_riodejaneiro_sigmob/holidays/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/holidays/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.holidays AS
 SELECT 
 DATE(SAFE_CAST(Data AS DATETIME)) data,
 REPLACE(content,"None","") content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.holidays as t

--- a/bases/br_rj_riodejaneiro_sigmob/linhas/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/linhas/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.linhas AS
 SELECT 
 SAFE_CAST(linha_id AS STRING) linha_id,
 REPLACE(content,"None","") content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.linhas as t

--- a/bases/br_rj_riodejaneiro_sigmob/shapes/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/shapes/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.shapes AS
 SELECT 
 SAFE_CAST(shape_id AS STRING) shape_id,
 REPLACE(content, "None", '') content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.shapes as t

--- a/bases/br_rj_riodejaneiro_sigmob/stop_details/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/stop_details/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.stop_details AS
 SELECT 
 SAFE_CAST(stop_id AS STRING) stop_id,
 REPLACE(content,"None","") content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.stop_details as t

--- a/bases/br_rj_riodejaneiro_sigmob/stop_times/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/stop_times/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.stop_times AS
 SELECT 
 SAFE_CAST(stop_id AS STRING) stop_id,
 REPLACE(content,"None","") content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.stop_times as t

--- a/bases/br_rj_riodejaneiro_sigmob/stops/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/stops/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.stops AS
 SELECT 
 SAFE_CAST(stop_id AS STRING) stop_id,
 REPLACE(content, "None", '') content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.stops as t

--- a/bases/br_rj_riodejaneiro_sigmob/trips/publish.sql
+++ b/bases/br_rj_riodejaneiro_sigmob/trips/publish.sql
@@ -23,5 +23,5 @@ CREATE VIEW rj-smtr.br_rj_riodejaneiro_sigmob.trips AS
 SELECT 
 SAFE_CAST(trip_id AS STRING) trip_id,
 REPLACE(content,"None","") content,
-SAFE_CAST(data_versao AS STRING) data_versao
+SAFE_CAST(data_versao AS DATE) data_versao
 from rj-smtr-staging.br_rj_riodejaneiro_sigmob_staging.trips as t


### PR DESCRIPTION
Descrição:
Modifica todos os arquivos `publish.sql` referente às tabelas staging do SIGMOB para que as views geradas em cima tipem a `data_versao` como `DATE`. Útil para diminuir os custos de query, uma vez que com o campo como `DATE` é possível se valer do particionamento da tabela externa, além da correta tipagem dos dados.